### PR TITLE
Update fetcher health check to match JSON logs

### DIFF
--- a/deploy/orco/stack.base.yaml
+++ b/deploy/orco/stack.base.yaml
@@ -47,7 +47,7 @@ services:
       - { target: postgres, require: ready }
       - { target: meili,    require: ready }
     health:
-      log: { pattern: "fetcher: ready" }
+      log: { pattern: '"service":"fetcher","msg":"ready"' }
     restartPolicy:
       maxRetries: 10
       backoff: { min: 500ms, max: 20s, factor: 1.8 }


### PR DESCRIPTION
## Summary
- update the fetcher service log health probe to look for the JSON-formatted ready message emitted by logx.Info

## Testing
- just up *(fails: `orco` binary not found in PATH)*
- just status *(not run due to previous failure)*

------
https://chatgpt.com/codex/tasks/task_e_68e42baaf9408325bcd0b4b76def06b1