### PR TITLE
Preserve cached feed headers after 304 responses

### DIFF
--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -50,6 +50,8 @@ func (f *Fetcher) Fetch(ctx context.Context, url, etag, lastModified string) (Re
 
 	res := Result{Status: resp.StatusCode}
 	if resp.StatusCode == http.StatusNotModified {
+		res.ETag = etag
+		res.LastModified = lastModified
 		return res, nil
 	}
 

--- a/internal/feed/fetcher_test.go
+++ b/internal/feed/fetcher_test.go
@@ -1,0 +1,59 @@
+package feed
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetcherPreservesHeadersOnNotModified(t *testing.T) {
+	var count int
+	const (
+		etag         = "W/\"123\""
+		lastModified = "Mon, 02 Jan 2006 15:04:05 GMT"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Last-Modified", lastModified)
+		if count == 1 {
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>Test</title></channel></rss>`))
+			return
+		}
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	t.Cleanup(srv.Close)
+
+	fetcher := NewFetcher()
+	ctx := context.Background()
+
+	res, err := fetcher.Fetch(ctx, srv.URL, "", "")
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if res.Status != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", res.Status)
+	}
+	if res.ETag != etag {
+		t.Fatalf("expected etag %q, got %q", etag, res.ETag)
+	}
+	if res.LastModified != lastModified {
+		t.Fatalf("expected last modified %q, got %q", lastModified, res.LastModified)
+	}
+
+	res, err = fetcher.Fetch(ctx, srv.URL, res.ETag, res.LastModified)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if res.Status != http.StatusNotModified {
+		t.Fatalf("expected status 304, got %d", res.Status)
+	}
+	if res.ETag != etag {
+		t.Fatalf("expected etag %q on 304, got %q", etag, res.ETag)
+	}
+	if res.LastModified != lastModified {
+		t.Fatalf("expected last modified %q on 304, got %q", lastModified, res.LastModified)
+	}
+}


### PR DESCRIPTION
## Summary
- keep previously supplied ETag and Last-Modified values when a feed returns 304 so crawl state is not cleared
- add a regression test that exercises a 200 -> 304 sequence to ensure headers remain populated

## Testing
- `go test ./internal/feed -run TestFetcherPreservesHeadersOnNotModified -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68e437ff71988325b93c7fa4fbfb661b