### PR TITLE
Update sqlc recipe to use configuration file

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@ set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 
 # Variables
 BIN := "./bin"
-STACK ?= "deploy/orco/stack.dev.yaml"
+STACK := env_var_or_default('STACK', 'deploy/orco/stack.dev.yaml')
 
 # Default recipe
 default: help
@@ -27,7 +27,7 @@ deps:
     cd web && npm install
 
 sqlc:
-    sqlc generate
+    sqlc generate --file db/sqlc.yaml
 
 goose-up:
     : "${COURIER_DSN:?Set COURIER_DSN env (matches deploy/orco/secrets/api.env)}"


### PR DESCRIPTION
## Summary
- default the STACK variable via `env_var_or_default` to keep overrides working
- run `sqlc generate` with the repository's configuration file so the CLI resolves paths correctly

## Testing
- ~/.cargo/bin/just sqlc

------
https://chatgpt.com/codex/tasks/task_e_68e43ecf0858832585180d49c776c360