### PR TITLE
Add conditional feed caching and per-feed crawl reporting

### DIFF
--- a/cmd/fetcher/main_test.go
+++ b/cmd/fetcher/main_test.go
@@ -104,7 +104,7 @@ func TestFetchFeedSkipsUpdateOnNotModified(t *testing.T) {
 	ctx := context.Background()
 	feedRecord := store.Feed{ID: "feed-1", URL: "http://example.com/feed"}
 
-	result := FetchFeed(ctx, "fetcher", repo, searchClient, fetcher, backoffs, feedRecord)
+	result := FetchFeed(ctx, repo, searchClient, fetcher, backoffs, feedRecord)
 	if result.Status != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", result.Status)
 	}
@@ -127,7 +127,7 @@ func TestFetchFeedSkipsUpdateOnNotModified(t *testing.T) {
 	feedRecord.ETag = sql.NullString{Valid: true, String: etag}
 	feedRecord.LastModified = sql.NullString{Valid: true, String: lastModified}
 
-	second := FetchFeed(ctx, "fetcher", repo, searchClient, fetcher, backoffs, feedRecord)
+	second := FetchFeed(ctx, repo, searchClient, fetcher, backoffs, feedRecord)
 	if second.Status != http.StatusNotModified {
 		t.Fatalf("expected status 304, got %d", second.Status)
 	}

--- a/db/queries/feeds.sql
+++ b/db/queries/feeds.sql
@@ -12,8 +12,8 @@ ORDER BY title ASC, url ASC;
 
 -- name: UpdateFeedCrawlState :one
 UPDATE feeds
-SET etag = sqlc.arg(etag),
-    last_modified = sqlc.arg(last_modified),
+SET etag = COALESCE(sqlc.arg(etag), feeds.etag),
+    last_modified = COALESCE(sqlc.arg(last_modified), feeds.last_modified),
     last_crawled = COALESCE(sqlc.arg(last_crawled), last_crawled),
     title = COALESCE(NULLIF(sqlc.arg(new_title)::text, ''), title)
 WHERE id = sqlc.arg(id)

--- a/internal/feed/fetch.go
+++ b/internal/feed/fetch.go
@@ -51,9 +51,20 @@ func (f *Fetcher) Fetch(ctx context.Context, url, etag, lastModified string) (Re
 	defer resp.Body.Close()
 
 	res := Result{Status: resp.StatusCode}
+	currentETag := resp.Header.Get("ETag")
+	currentLastModified := resp.Header.Get("Last-Modified")
+
 	if resp.StatusCode == http.StatusNotModified {
-		res.ETag = etag
-		res.LastModified = lastModified
+		if currentETag != "" {
+			res.ETag = currentETag
+		} else {
+			res.ETag = etag
+		}
+		if currentLastModified != "" {
+			res.LastModified = currentLastModified
+		} else {
+			res.LastModified = lastModified
+		}
 		return res, nil
 	}
 
@@ -73,8 +84,8 @@ func (f *Fetcher) Fetch(ctx context.Context, url, etag, lastModified string) (Re
 	}
 
 	res.Feed = feed
-	res.ETag = resp.Header.Get("ETag")
-	res.LastModified = resp.Header.Get("Last-Modified")
+	res.ETag = currentETag
+	res.LastModified = currentLastModified
 	if res.ETag == "" {
 		res.ETag = etag
 	}

--- a/internal/store/sqlc/feeds.sql.go
+++ b/internal/store/sqlc/feeds.sql.go
@@ -74,8 +74,8 @@ func (q *Queries) ListFeeds(ctx context.Context, active bool) ([]Feed, error) {
 
 const updateFeedCrawlState = `-- name: UpdateFeedCrawlState :one
 UPDATE feeds
-SET etag = $1,
-    last_modified = $2,
+SET etag = COALESCE($1, feeds.etag),
+    last_modified = COALESCE($2, feeds.last_modified),
     last_crawled = COALESCE($3, last_crawled),
     title = COALESCE(NULLIF($4::text, ''), title)
 WHERE id = $5


### PR DESCRIPTION
## Summary
- update the feed fetcher to surface per-feed crawl results and reasons for skips or errors
- capture conditional request metadata on HTTP 200/304 responses and preserve stored values when headers are absent
- adjust the crawl state SQL to avoid clobbering cached etag/last-modified values when updates omit them

## Testing
- go test ./...
- just build
- just up *(fails: scripts/orco.sh: line 7: exec: orco: not found)*
- just logs *(fails: scripts/orco.sh: line 7: exec: orco: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e58a9825188325a98cfd6821bffec8