### PR TITLE
Create urlcanon package for URL normalization

### DIFF
--- a/internal/item/item_test.go
+++ b/internal/item/item_test.go
@@ -1,36 +1,19 @@
 package item
 
-import "testing"
+import (
+	"testing"
 
-func TestNormalizeURL(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{
-			name: "strips utm and fragment",
-			in:   "https://Example.com:443/path?utm_source=test&ref=keep#section",
-			want: "https://example.com/path?ref=keep",
-		},
-		{
-			name: "removes default port and trims spaces",
-			in:   "  http://BLOG.example.com:80/post?id=42&fbclid=abc  ",
-			want: "http://blog.example.com/post?id=42",
-		},
-		{
-			name: "handles invalid url",
-			in:   "not a url",
-			want: "not a url",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := normalizeURL(tc.in)
-			if got != tc.want {
-				t.Fatalf("normalizeURL(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
+	"github.com/mmcdole/gofeed"
+)
+
+func TestFromFeedItemNormalizesURL(t *testing.T) {
+	feedItem := &gofeed.Item{Link: " https://WWW.Example.com:443/posts/Go/?utm_source=rss&fbclid=abc#section "}
+
+	params := FromFeedItem("feed-1", feedItem)
+
+	const want = "https://example.com/posts/Go"
+	if params.URL != want {
+		t.Fatalf("FromFeedItem URL = %q, want %q", params.URL, want)
 	}
 }
 

--- a/internal/item/urlcanon/normalize.go
+++ b/internal/item/urlcanon/normalize.go
@@ -1,0 +1,91 @@
+package urlcanon
+
+import (
+	"net/url"
+	pathpkg "path"
+	"strings"
+)
+
+var trackingParameters = map[string]struct{}{
+	"fbclid": {},
+	"gclid":  {},
+	"gclsrc": {},
+	"mc_cid": {},
+	"mc_eid": {},
+}
+
+// Normalize canonicalizes the provided URL string for consistent storage and comparison.
+// It trims whitespace, lowercases the scheme and host, strips a leading "www.", removes
+// default ports and fragments, eliminates common tracking parameters, and removes trailing
+// slashes while keeping the root path intact. Invalid URLs are returned unchanged.
+func Normalize(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" {
+		return raw
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+
+	host := strings.ToLower(parsed.Hostname())
+	if strings.HasPrefix(host, "www.") && len(host) > len("www.") {
+		host = strings.TrimPrefix(host, "www.")
+	}
+
+	port := parsed.Port()
+	if port != "" {
+		if (parsed.Scheme == "http" && port == "80") || (parsed.Scheme == "https" && port == "443") {
+			port = ""
+		}
+	}
+
+	if port != "" {
+		parsed.Host = host + ":" + port
+	} else {
+		parsed.Host = host
+	}
+
+	if parsed.Path != "" {
+		cleaned := pathpkg.Clean(parsed.Path)
+		if cleaned == "." {
+			cleaned = ""
+		}
+		if cleaned != "/" {
+			cleaned = strings.TrimSuffix(cleaned, "/")
+		}
+		parsed.Path = cleaned
+	}
+
+	parsed.Fragment = ""
+
+	if parsed.RawQuery != "" {
+		query := parsed.Query()
+		for key := range query {
+			lower := strings.ToLower(key)
+			if strings.HasPrefix(lower, "utm_") || isTrackingParameter(lower) {
+				query.Del(key)
+			}
+		}
+		if len(query) == 0 {
+			parsed.RawQuery = ""
+		} else {
+			parsed.RawQuery = query.Encode()
+		}
+	}
+
+	if parsed.Path == "" && strings.HasSuffix(raw, "/") {
+		// Preserve an explicit root path when the original URL ended with a slash.
+		parsed.Path = "/"
+	}
+
+	return parsed.String()
+}
+
+func isTrackingParameter(name string) bool {
+	_, ok := trackingParameters[name]
+	return ok
+}

--- a/internal/item/urlcanon/normalize_test.go
+++ b/internal/item/urlcanon/normalize_test.go
@@ -1,0 +1,61 @@
+package urlcanon
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "mixed case scheme and host with tracking",
+			in:   " HTTPS://Example.COM:443/posts/Go/?utm_source=rss&utm_medium=feed&ref=keep#fragment ",
+			want: "https://example.com/posts/Go?ref=keep",
+		},
+		{
+			name: "strips leading www and preserves root path",
+			in:   "https://www.Example.com/",
+			want: "https://example.com/",
+		},
+		{
+			name: "removes default port",
+			in:   "http://WWW.example.com:80/path",
+			want: "http://example.com/path",
+		},
+		{
+			name: "keeps non default port",
+			in:   "https://www.example.com:8443/path/",
+			want: "https://example.com:8443/path",
+		},
+		{
+			name: "drops trailing slash on non root path",
+			in:   "https://example.com/foo/bar/",
+			want: "https://example.com/foo/bar",
+		},
+		{
+			name: "removes known tracking parameters",
+			in:   "https://example.com/?id=42&fbclid=abc&utm_campaign=test&gclid=123",
+			want: "https://example.com/?id=42",
+		},
+		{
+			name: "invalid url returned unchanged",
+			in:   "not a url",
+			want: "not a url",
+		},
+		{
+			name: "empty input",
+			in:   "   \t   ",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Normalize(tt.in)
+			if got != tt.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add an internal/item/urlcanon package with Normalize to canonicalize URLs by trimming, lowercasing, stripping tracking params, and handling default ports and slashes
- switch item.FromFeedItem to use the new canonicalizer and cover it with unit tests
- extend the fetcher tests to ensure canonicalized URLs are stored and indexed

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5afb26e748325b7dd3a16d4d9480d