### PR TITLE
Normalize item URLs before fetcher upserts

### DIFF
--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -13,6 +13,7 @@ import (
 
 	"courier/internal/feed"
 	"courier/internal/item"
+	"courier/internal/item/urlcanon"
 	"courier/internal/logx"
 	"courier/internal/search"
 	"courier/internal/store"
@@ -219,6 +220,7 @@ func FetchFeed(ctx context.Context, repo feedStore, searchClient documentIndexer
 	var docs []search.Document
 	for _, entry := range res.Feed.Items {
 		params := item.FromFeedItem(f.ID, entry)
+		params.URL = urlcanon.Normalize(params.URL)
 		output, err := repo.UpsertItem(ctx, params)
 		if err != nil {
 			wrapped := fmt.Errorf("upsert item: %w", err)

--- a/internal/item/urlcanon/normalize.go
+++ b/internal/item/urlcanon/normalize.go
@@ -17,7 +17,7 @@ var trackingParameters = map[string]struct{}{
 // Normalize canonicalizes the provided URL string for consistent storage and comparison.
 // It trims whitespace, lowercases the scheme and host, strips a leading "www.", removes
 // default ports and fragments, eliminates common tracking parameters, and removes trailing
-// slashes while keeping the root path intact. Invalid URLs are returned unchanged.
+// slashes. Invalid URLs are returned unchanged.
 func Normalize(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -54,10 +54,10 @@ func Normalize(raw string) string {
 		if cleaned == "." {
 			cleaned = ""
 		}
-		if cleaned != "/" {
-			cleaned = strings.TrimSuffix(cleaned, "/")
+		if cleaned == "/" {
+			cleaned = ""
 		}
-		parsed.Path = cleaned
+		parsed.Path = strings.TrimSuffix(cleaned, "/")
 	}
 
 	parsed.Fragment = ""
@@ -75,11 +75,6 @@ func Normalize(raw string) string {
 		} else {
 			parsed.RawQuery = query.Encode()
 		}
-	}
-
-	if parsed.Path == "" && strings.HasSuffix(raw, "/") {
-		// Preserve an explicit root path when the original URL ended with a slash.
-		parsed.Path = "/"
 	}
 
 	return parsed.String()

--- a/internal/item/urlcanon/normalize_test.go
+++ b/internal/item/urlcanon/normalize_test.go
@@ -10,13 +10,13 @@ func TestNormalize(t *testing.T) {
 	}{
 		{
 			name: "mixed case scheme and host with tracking",
-			in:   " HTTPS://Example.COM:443/posts/Go/?utm_source=rss&utm_medium=feed&ref=keep#fragment ",
+			in:   " HTTPS://Example.COM:443/posts/Go/?utm_source=rss&utm_medium=feed&ref=keep#gclid ",
 			want: "https://example.com/posts/Go?ref=keep",
 		},
 		{
-			name: "strips leading www and preserves root path",
+			name: "strips leading www and root slash",
 			in:   "https://www.Example.com/",
-			want: "https://example.com/",
+			want: "https://example.com",
 		},
 		{
 			name: "removes default port",
@@ -29,14 +29,24 @@ func TestNormalize(t *testing.T) {
 			want: "https://example.com:8443/path",
 		},
 		{
-			name: "drops trailing slash on non root path",
-			in:   "https://example.com/foo/bar/",
-			want: "https://example.com/foo/bar",
+			name: "drops trailing slash before query",
+			in:   "https://example.com/foo/?utm_source=feed&keep=1",
+			want: "https://example.com/foo?keep=1",
 		},
 		{
-			name: "removes known tracking parameters",
-			in:   "https://example.com/?id=42&fbclid=abc&utm_campaign=test&gclid=123",
-			want: "https://example.com/?id=42",
+			name: "removes trailing root slash with query",
+			in:   "https://www.example.com/?utm_source=feed&Keep=1",
+			want: "https://example.com?Keep=1",
+		},
+		{
+			name: "removes tracking parameters with varied casing",
+			in:   "https://example.com/path/?ID=42&Fbclid=abc&utm_campaign=test&GCLID=123",
+			want: "https://example.com/path?ID=42",
+		},
+		{
+			name: "collapses redundant path segments",
+			in:   "https://example.com/a/b/../c/?utm_medium=feed",
+			want: "https://example.com/a/c",
 		},
 		{
 			name: "invalid url returned unchanged",


### PR DESCRIPTION
## Summary
- update the URL canonicalization helper to strip root trailing slashes and aggressively drop common tracking query parameters
- extend unit coverage with tricky URL inputs covering casing, redundant paths, and tracked query combinations
- normalize item URLs again inside the fetcher before upserting so tracked variants map to the same row

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5b83a33c48325bb0acae10010035f