### PR TITLE
Fix IPv6 host canonicalization

### DIFF
--- a/internal/item/urlcanon/normalize.go
+++ b/internal/item/urlcanon/normalize.go
@@ -1,6 +1,7 @@
 package urlcanon
 
 import (
+	"net"
 	"net/url"
 	pathpkg "path"
 	"strings"
@@ -44,9 +45,13 @@ func Normalize(raw string) string {
 	}
 
 	if port != "" {
-		parsed.Host = host + ":" + port
+		parsed.Host = net.JoinHostPort(host, port)
 	} else {
-		parsed.Host = host
+		if strings.Contains(host, ":") {
+			parsed.Host = "[" + host + "]"
+		} else {
+			parsed.Host = host
+		}
 	}
 
 	if parsed.Path != "" {

--- a/internal/item/urlcanon/normalize_test.go
+++ b/internal/item/urlcanon/normalize_test.go
@@ -39,6 +39,16 @@ func TestNormalize(t *testing.T) {
 			want: "https://example.com?Keep=1",
 		},
 		{
+			name: "retains ipv6 brackets without port",
+			in:   "http://[2001:db8::1]/path",
+			want: "http://[2001:db8::1]/path",
+		},
+		{
+			name: "retains ipv6 brackets when stripping default port",
+			in:   "https://[2001:db8::1]:443/?utm_source=x",
+			want: "https://[2001:db8::1]",
+		},
+		{
 			name: "removes tracking parameters with varied casing",
 			in:   "https://example.com/path/?ID=42&Fbclid=abc&utm_campaign=test&GCLID=123",
 			want: "https://example.com/path?ID=42",


### PR DESCRIPTION
## Summary
- wrap IPv6 hostnames in brackets after normalization while using net.JoinHostPort for explicit ports
- add IPv6-specific test cases to ensure canonical URLs preserve brackets and strip default ports

## Testing
- go test ./internal/item/...


------
https://chatgpt.com/codex/tasks/task_e_68e5bbbf751083258be558192416c931