### PR TITLE
Add HTML sanitizer for item content text

### DIFF
--- a/internal/item/htmlclean/clean.go
+++ b/internal/item/htmlclean/clean.go
@@ -1,0 +1,100 @@
+package htmlclean
+
+import (
+	"html"
+	"strings"
+
+	xhtml "golang.org/x/net/html"
+)
+
+const defaultMaxLength = 2048
+
+// CleanHTML converts an HTML fragment into a normalized text representation.
+// It strips tags (excluding their textual content), decodes HTML entities,
+// collapses repeated whitespace, and ensures the returned string does not
+// exceed the supplied maximum length (or a sensible default when max <= 0).
+func CleanHTML(input string, max int) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return ""
+	}
+
+	if max <= 0 {
+		max = defaultMaxLength
+	}
+
+	node, err := xhtml.Parse(strings.NewReader(trimmed))
+	if err != nil {
+		fallback := cleanupPunctuation(collapseWhitespace(html.UnescapeString(trimmed)))
+		return truncate(fallback, max)
+	}
+
+	var builder strings.Builder
+	walk(node, &builder)
+
+	cleaned := cleanupPunctuation(collapseWhitespace(builder.String()))
+	return truncate(cleaned, max)
+}
+
+func walk(n *xhtml.Node, builder *strings.Builder) {
+	if n == nil {
+		return
+	}
+
+	if n.Type == xhtml.ElementNode {
+		switch strings.ToLower(n.Data) {
+		case "script", "style":
+			return
+		}
+	}
+
+	if n.Type == xhtml.TextNode {
+		text := collapseWhitespace(html.UnescapeString(n.Data))
+		if text != "" {
+			if builder.Len() > 0 {
+				builder.WriteByte(' ')
+			}
+			builder.WriteString(text)
+		}
+	}
+
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		walk(child, builder)
+	}
+}
+
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+}
+
+var punctuationReplacer = strings.NewReplacer(
+	" !", "!",
+	" ?", "?",
+	" ,", ",",
+	" .", ".",
+	" ;", ";",
+	" :", ":",
+)
+
+func cleanupPunctuation(s string) string {
+	return punctuationReplacer.Replace(s)
+}
+
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+
+	truncated := strings.TrimSpace(string(runes[:max]))
+	if truncated == "" {
+		// If trimming removed everything, fall back to raw slice to avoid
+		// returning empty string when there is still content.
+		truncated = string(runes[:max])
+	}
+	return truncated
+}

--- a/internal/item/htmlclean/clean_test.go
+++ b/internal/item/htmlclean/clean_test.go
@@ -1,0 +1,53 @@
+package htmlclean
+
+import "testing"
+
+func TestCleanHTML(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input string
+		max   int
+		want  string
+	}{
+		"strips_tags_and_scripts": {
+			input: `<div><p>Hello <strong>world</strong>!<script>bad()</script></p><p>Second&nbsp;line</p></div>`,
+			max:   2048,
+			want:  "Hello world! Second line",
+		},
+		"decodes_entities_and_collapses_whitespace": {
+			input: "Hello\n\n&amp;nbsp;world\t!",
+			max:   2048,
+			want:  "Hello world!",
+		},
+		"handles_parse_errors": {
+			input: "Hello &amp; welcome < invalid>",
+			max:   2048,
+			want:  "Hello & welcome < invalid>",
+		},
+		"truncates_to_max": {
+			input: `<p>` + longString(2100) + `</p>`,
+			max:   2000,
+			want:  longString(2000),
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := CleanHTML(tc.input, tc.max); got != tc.want {
+				t.Fatalf("CleanHTML() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func longString(n int) string {
+	buf := make([]rune, n)
+	for i := range buf {
+		buf[i] = 'a'
+	}
+	return string(buf)
+}

--- a/internal/item/item_test.go
+++ b/internal/item/item_test.go
@@ -1,9 +1,9 @@
 package item
 
 import (
-	"testing"
+        "testing"
 
-	"github.com/mmcdole/gofeed"
+        "github.com/mmcdole/gofeed"
 )
 
 func TestFromFeedItemNormalizesURL(t *testing.T) {
@@ -17,11 +17,13 @@ func TestFromFeedItemNormalizesURL(t *testing.T) {
 	}
 }
 
-func TestSanitizeHTML(t *testing.T) {
-	html := `<div><p>Hello <strong>world</strong>!<script>bad()</script></p><p>Second line</p></div>`
-	got := sanitizeHTML(html)
-	const want = "Hello world! Second line"
-	if got != want {
-		t.Fatalf("sanitizeHTML() = %q, want %q", got, want)
-	}
+func TestFromFeedItemSanitizesHTML(t *testing.T) {
+        feedItem := &gofeed.Item{Content: `<div><p>Hello <strong>world</strong>!<script>bad()</script></p><p>Second&nbsp;line</p></div>`}
+
+        params := FromFeedItem("feed-1", feedItem)
+
+        const want = "Hello world! Second line"
+        if params.ContentText != want {
+                t.Fatalf("FromFeedItem ContentText = %q, want %q", params.ContentText, want)
+        }
 }


### PR DESCRIPTION
## Summary
- add an htmlclean helper that normalizes HTML into truncated plain text
- sanitize feed item content and description text before storing it
- cover the sanitizer with unit tests and update the item tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5bd967f5483258f689c3e4258c4a2