### PR TITLE
Improve HTML text sanitizer

### DIFF
--- a/internal/item/htmlclean/clean_test.go
+++ b/internal/item/htmlclean/clean_test.go
@@ -15,6 +15,11 @@ func TestCleanHTML(t *testing.T) {
 			max:   2048,
 			want:  "Hello world! Second line",
 		},
+		"ignores_style_blocks": {
+			input: `<style>body{color:red}</style><p>Visible <em>text</em></p>`,
+			max:   2048,
+			want:  "Visible text",
+		},
 		"decodes_entities_and_collapses_whitespace": {
 			input: "Hello\n\n&amp;nbsp;world\t!",
 			max:   2048,
@@ -25,10 +30,20 @@ func TestCleanHTML(t *testing.T) {
 			max:   2048,
 			want:  "Hello & welcome < invalid>",
 		},
+		"returns_empty_for_blank_input": {
+			input: "  \n\t  ",
+			max:   2048,
+			want:  "",
+		},
 		"truncates_to_max": {
 			input: `<p>` + longString(2100) + `</p>`,
 			max:   2000,
 			want:  longString(2000),
+		},
+		"defaults_max_when_non_positive": {
+			input: `<div>` + longString(defaultMaxLength+10) + `</div>`,
+			max:   0,
+			want:  longString(defaultMaxLength),
 		},
 	}
 


### PR DESCRIPTION
## Summary
- parse HTML fragments when cleaning content text so script/style blocks are skipped and whitespace is normalized before truncation
- expand unit coverage for CleanHTML including style removal, blank input handling, and default length behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5bf5f3a048325968f7951c3de3b0c