### PR TITLE
Refine whitespace handling in HTML sanitizer

### DIFF
--- a/internal/item/htmlclean/clean_test.go
+++ b/internal/item/htmlclean/clean_test.go
@@ -20,6 +20,11 @@ func TestCleanHTML(t *testing.T) {
 			max:   2048,
 			want:  "Visible text",
 		},
+		"preserves_inline_boundaries_without_spaces": {
+			input: `<strong>Hello</strong><em>world</em>`,
+			max:   2048,
+			want:  "Helloworld",
+		},
 		"decodes_entities_and_collapses_whitespace": {
 			input: "Hello\n\n&amp;nbsp;world\t!",
 			max:   2048,


### PR DESCRIPTION
## Summary
- adjust the HTML cleaner to track whitespace context so separators are only inserted when original whitespace was present, while still ensuring block element boundaries create spacing
- add a unit test covering inline element boundaries to confirm `<strong>Hello</strong><em>world</em>` is sanitized to `Helloworld`

## Testing
- go test ./internal/item/htmlclean

------
https://chatgpt.com/codex/tasks/task_e_68e646594f4c832580cf593367137f62