### PR TITLE
Improve HTML sanitization for content text

### DIFF
--- a/cmd/fetcher/main_test.go
+++ b/cmd/fetcher/main_test.go
@@ -185,6 +185,45 @@ func TestFetchFeedCanonicalizesItemURLs(t *testing.T) {
 	}
 }
 
+func TestFetchFeedSanitizesContentText(t *testing.T) {
+	repo := &stubFeedStore{}
+	searchClient := &stubSearchClient{}
+	fetcher := &stubFetcher{responses: []fetchResponse{{
+		result: feed.Result{
+			Status: http.StatusOK,
+			Feed: &gofeed.Feed{
+				Items: []*gofeed.Item{{
+					Title:   "Example post",
+					Content: `<p>Hello&nbsp;<em>world</em>!<script>bad()</script></p>`,
+				}},
+			},
+		},
+	}}}
+
+	ctx := context.Background()
+	feedRecord := store.Feed{ID: "feed-1", URL: "http://example.com/feed"}
+
+	result := FetchFeed(ctx, repo, searchClient, fetcher, newBackoffTracker(), feedRecord)
+	if result.Status != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", result.Status)
+	}
+	if len(repo.upserts) != 1 {
+		t.Fatalf("expected one item upsert, got %d", len(repo.upserts))
+	}
+
+	const wantContent = "Hello world!"
+	if repo.upserts[0].ContentText != wantContent {
+		t.Fatalf("stored content text = %q, want %q", repo.upserts[0].ContentText, wantContent)
+	}
+
+	if len(searchClient.calls) != 1 || len(searchClient.calls[0]) != 1 {
+		t.Fatalf("expected one document upsert call with one document, got %+v", searchClient.calls)
+	}
+	if searchClient.calls[0][0].ContentText != wantContent {
+		t.Fatalf("indexed content text = %q, want %q", searchClient.calls[0][0].ContentText, wantContent)
+	}
+}
+
 // Ensure stub satisfies interfaces at compile time.
 var _ feedStore = (*stubFeedStore)(nil)
 var _ documentIndexer = (*stubSearchClient)(nil)

--- a/internal/item/htmlclean/clean_test.go
+++ b/internal/item/htmlclean/clean_test.go
@@ -20,10 +20,10 @@ func TestCleanHTML(t *testing.T) {
 			max:   2048,
 			want:  "Visible text",
 		},
-		"preserves_inline_boundaries_without_spaces": {
+		"preserves_inline_boundaries_with_separator": {
 			input: `<strong>Hello</strong><em>world</em>`,
 			max:   2048,
-			want:  "Helloworld",
+			want:  "Hello world",
 		},
 		"decodes_entities_and_collapses_whitespace": {
 			input: "Hello\n\n&amp;nbsp;world\t!",


### PR DESCRIPTION
## Summary
- improve the HTML text cleaner so adjacent inline nodes receive separators when necessary while preserving punctuation and whitespace handling
- expand tests to cover the new separator behaviour and ensure fetched items store sanitized content text for indexing

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e64a14656c8325a85f094839618273