### PR TITLE
Add search client batch upsert helper

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"courier/internal/logx"
 	meilisearch "github.com/meilisearch/meilisearch-go"
 )
 
@@ -126,6 +127,17 @@ func (c *Client) UpsertDocuments(ctx context.Context, docs []Document) error {
 	if len(docs) == 0 {
 		return nil
 	}
+	_, err := c.client.Index(c.index).UpdateDocumentsWithContext(ctx, docs)
+	return err
+}
+
+func (c *Client) UpsertBatch(ctx context.Context, docs []Document) error {
+	if len(docs) == 0 {
+		return nil
+	}
+
+	logx.Info(c.svc, "upsert batch", map[string]any{"index": c.index, "batch_size": len(docs)})
+
 	_, err := c.client.Index(c.index).UpdateDocumentsWithContext(ctx, docs)
 	return err
 }


### PR DESCRIPTION
## Summary
- add a Client.UpsertBatch helper for Meilisearch document batches
- log batch size and index prior to invoking Meilisearch updates

## Testing
- go test ./... (fails: command interrupted due to hanging)

------
https://chatgpt.com/codex/tasks/task_e_68e655272110832592a3fe7edda11fb2