### PR TITLE
Track indexed item updates

### DIFF
--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -305,6 +305,9 @@ func FetchFeed(ctx context.Context, repo feedStore, _ documentIndexer, fetcher f
 			}
 			continue
 		}
+		if !output.Indexed {
+			continue
+		}
 		doc := search.Document{
 			ID:          output.Item.ID,
 			FeedID:      output.Item.FeedID,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -115,8 +115,9 @@ type UpsertItemParams struct {
 }
 
 type UpsertItemResult struct {
-	Item  Item
-	Fresh bool
+	Item    Item
+	Fresh   bool
+	Indexed bool
 }
 
 func (s *Store) UpsertItem(ctx context.Context, arg UpsertItemParams) (UpsertItemResult, error) {
@@ -142,7 +143,10 @@ func (s *Store) UpsertItem(ctx context.Context, arg UpsertItemParams) (UpsertIte
 	}
 
 	item := mapItem(row.ID, row.FeedID, row.FeedTitle, row.Guid, row.Url, row.Title, row.Author, row.ContentHtml, row.ContentText, row.PublishedAt, row.RetrievedAt)
-	return UpsertItemResult{Item: item, Fresh: row.Inserted}, nil
+
+	indexed := row.Indexed.Valid && row.Indexed.Bool
+
+	return UpsertItemResult{Item: item, Fresh: row.Inserted, Indexed: indexed}, nil
 }
 
 type ListRecentParams struct {


### PR DESCRIPTION
## Summary
- compute an indexed flag in the item upsert query and regenerate sqlc models
- expose the flag through the store API and only enqueue changed items for search
- add coverage that unchanged items skip search indexing while mutations are indexed

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e661781128832582583b57849611fd