### PR TITLE
Validate feed_id query parameters in items endpoint

### DIFF
--- a/internal/httpx/server.go
+++ b/internal/httpx/server.go
@@ -12,6 +12,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
+	"github.com/google/uuid"
+
 	"courier/internal/logx"
 	"courier/internal/search"
 	"courier/internal/store"
@@ -87,6 +89,11 @@ func NewServer(cfg Config) *echo.Echo {
 		limit := parseInt(c.QueryParam("limit"), 50)
 		offset := parseInt(c.QueryParam("offset"), 0)
 		feedIDs := c.QueryParams()["feed_id"]
+		for _, id := range feedIDs {
+			if _, err := uuid.Parse(id); err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "invalid feed_id")
+			}
+		}
 		sortParam := c.QueryParam("sort")
 		if sortParam == "" {
 			sortParam = "published_at:desc"


### PR DESCRIPTION
## Summary
- validate each feed_id query parameter in the /items handler before invoking the store
- return a 400 Bad Request error when a feed_id cannot be parsed

## Testing
- go test ./internal/httpx/...


------
https://chatgpt.com/codex/tasks/task_e_68e678ab84408325a1216b1d31fe034a