### PR TITLE
Refactor ItemTable to use server-driven pagination

### DIFF
--- a/web/src/components/ItemTable.tsx
+++ b/web/src/components/ItemTable.tsx
@@ -1,16 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
 import {
   flexRender,
   getCoreRowModel,
-  getSortedRowModel,
   useReactTable,
   type Column,
   type ColumnDef,
+  type ColumnFiltersState,
+  type PaginationState,
   type SortingState,
 } from '@tanstack/react-table'
 import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import type { Item } from '@/lib/api'
+import { listRecentItems } from '@/lib/api'
+import { queryKeys } from '@/lib/query'
 
 function formatDate(value?: string | null) {
   if (!value) {
@@ -28,14 +34,16 @@ function formatDate(value?: string | null) {
 
 const columns: ColumnDef<Item>[] = [
   {
-    header: ({ column }) => <SortableHeader column={column} label="Feed" />,
-    accessorKey: 'feed_title',
+    id: 'feed_id',
+    accessorFn: (row) => row.feed_id,
+    header: 'Feed',
     cell: ({ row }) => (
       <span className="font-medium text-sm text-muted-foreground">{
         row.original.feed_title
       }</span>
     ),
-    enableSorting: true,
+    enableSorting: false,
+    enableColumnFilter: true,
   },
   {
     header: 'Title',
@@ -70,80 +78,202 @@ const columns: ColumnDef<Item>[] = [
       </span>
     ),
     enableSorting: true,
-    sortingFn: (rowA, rowB) => {
-      const valueA = rowA.original.published_at ?? rowA.original.retrieved_at
-      const valueB = rowB.original.published_at ?? rowB.original.retrieved_at
-      if (!valueA && !valueB) return 0
-      if (!valueA) return -1
-      if (!valueB) return 1
-      const timeA = Date.parse(valueA)
-      const timeB = Date.parse(valueB)
-      return timeA - timeB
-    },
   },
 ]
 
+const DEFAULT_PAGE_SIZE = 20
+
 interface ItemTableProps {
-  items: Item[]
+  feedId?: string
+  pageSize?: number
 }
 
-export default function ItemTable({ items }: ItemTableProps) {
+export default function ItemTable({ feedId, pageSize = DEFAULT_PAGE_SIZE }: ItemTableProps) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'published_at', desc: true },
   ])
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize,
+  })
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() =>
+    feedId ? [{ id: 'feed_id', value: [feedId] }] : [],
+  )
+
+  useEffect(() => {
+    setPagination((prev) => {
+      if (prev.pageSize === pageSize) {
+        return prev
+      }
+      return { pageIndex: 0, pageSize }
+    })
+  }, [pageSize])
+
+  useEffect(() => {
+    setColumnFilters((current) => {
+      const existing = current.find((filter) => filter.id === 'feed_id')
+      const nextValue = feedId ? [feedId] : []
+
+      if (feedId) {
+        if (
+          existing &&
+          Array.isArray(existing.value) &&
+          arraysEqual(existing.value as string[], nextValue)
+        ) {
+          return current
+        }
+        return [
+          ...current.filter((filter) => filter.id !== 'feed_id'),
+          { id: 'feed_id', value: nextValue },
+        ]
+      }
+
+      if (!existing) {
+        return current
+      }
+
+      return current.filter((filter) => filter.id !== 'feed_id')
+    })
+  }, [feedId])
+
+  useEffect(() => {
+    setPagination((prev) => {
+      if (prev.pageIndex === 0) {
+        return prev
+      }
+      return { ...prev, pageIndex: 0 }
+    })
+  }, [sorting, columnFilters])
+
+  const feedFilter = columnFilters.find((filter) => filter.id === 'feed_id')
+  const feedIds = normalizeFilterValue(feedFilter?.value)
+  const sortedFeedIds = [...feedIds].sort()
+  const effectiveFeedIds = sortedFeedIds.length > 0 ? sortedFeedIds : undefined
+  const sortState = sorting[0]
+  const sortParam = sortState
+    ? `${sortState.id}:${sortState.desc ? 'desc' : 'asc'}`
+    : undefined
+  const limit = pagination.pageSize
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  const itemsQuery = useQuery({
+    queryKey: queryKeys.recentItems({
+      limit,
+      offset,
+      sort: sortParam,
+      feed_id: effectiveFeedIds,
+    }),
+    queryFn: () =>
+      listRecentItems({
+        limit,
+        offset,
+        sort: sortParam,
+        feed_id: effectiveFeedIds,
+      }),
+    keepPreviousData: false,
+  })
+
+  const items = itemsQuery.data?.items ?? []
+  const total = itemsQuery.data?.total ?? 0
+  const pageCount = limit > 0 ? Math.ceil(total / limit) : 0
+  const rowCount = total
+  const showSkeleton = itemsQuery.isLoading || itemsQuery.isFetching
+
   const table = useReactTable({
     data: items,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    state: { sorting },
+    state: { sorting, pagination, columnFilters },
     onSortingChange: setSorting,
-    manualSorting: false,
+    onPaginationChange: setPagination,
+    onColumnFiltersChange: setColumnFilters,
+    manualSorting: true,
+    manualPagination: true,
+    manualFiltering: true,
+    pageCount,
   })
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border bg-card">
-      <table className="min-w-full divide-y divide-border">
-        <thead className="bg-muted/60">
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th
-                  key={header.id}
-                  scope="col"
-                  className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody className="divide-y divide-border">
-          {table.getRowModel().rows.length === 0 ? (
-            <tr>
-              <td
-                colSpan={columns.length}
-                className="px-4 py-6 text-center text-sm text-muted-foreground"
-              >
-                No items yet. Add feeds to start populating the timeline.
-              </td>
-            </tr>
-          ) : (
-            table.getRowModel().rows.map((row) => (
-              <tr key={row.id} className="hover:bg-muted/40">
-                {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className="px-4 py-3 align-top">
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
+    <div className="space-y-4">
+      <div className="overflow-hidden rounded-xl border border-border bg-card">
+        <table className="min-w-full divide-y divide-border">
+          <thead className="bg-muted/60">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </th>
                 ))}
               </tr>
-            ))
-          )}
-        </tbody>
-      </table>
+            ))}
+          </thead>
+          <tbody className="divide-y divide-border">
+            {showSkeleton ? (
+              Array.from({ length: pagination.pageSize }).map((_, index) => (
+                <tr key={`skeleton-${index}`} className="hover:bg-transparent">
+                  <td colSpan={columns.length} className="px-4 py-3">
+                    <Skeleton className="h-6 w-full" />
+                  </td>
+                </tr>
+              ))
+            ) : table.getRowModel().rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="px-4 py-6 text-center text-sm text-muted-foreground"
+                >
+                  No items yet. Add feeds to start populating the timeline.
+                </td>
+              </tr>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <tr key={row.id} className="hover:bg-muted/40">
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-4 py-3 align-top">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-muted-foreground">
+          {showSkeleton
+            ? 'Loading items…'
+            : `Showing ${
+                items.length > 0 ? `${offset + 1}-${offset + items.length}` : 0
+              } of ${rowCount} items`}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage() || showSkeleton}
+          >
+            Previous
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            Page {pagination.pageIndex + 1} of {Math.max(pageCount, 1)}
+          </span>
+          <Button
+            variant="outline"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage() || showSkeleton}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
     </div>
   )
 }
@@ -178,4 +308,21 @@ function SortableHeader({ column, label }: SortableHeaderProps) {
       </span>
     </button>
   )
+}
+
+function normalizeFilterValue(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.length > 0)
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return [value]
+  }
+  return []
+}
+
+function arraysEqual(a: string[], b: string[]) {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((value, index) => value === b[index])
 }

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -44,7 +44,7 @@ function RecentItemsRoute() {
     queryFn: () => listRecentItems({ limit: LIMIT, feed_id: feed || undefined }),
   })
 
-  const items = itemsQuery.data ?? []
+  const items = itemsQuery.data?.items ?? []
   const feeds = feedsQuery.data ?? []
   const activeFeed = feed ? feeds.find((f) => f.id === feed) : undefined
   const feedSelection = feed || 'all'
@@ -115,7 +115,7 @@ function RecentItemsRoute() {
         ) : (
           <>
             {showTable ? (
-              <ItemTable items={items} />
+              <ItemTable feedId={feed || undefined} />
             ) : (
               <div className="grid gap-6 md:grid-cols-2">
                 {items.map((item) => (


### PR DESCRIPTION
## Summary
- refactor the item table to manage TanStack Table sorting, pagination, and feed filters locally while fetching data through TanStack Query
- add loading skeleton rows, manual pagination controls, and server-driven row counts for the table
- extend the API client helper to accept sorting/filter params and expose total counts for recent items

## Testing
- pnpm run build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e67dce1cf08325b82b136ab85a2e74