### PR TITLE
Enhance recent items filtering and sorting

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -59,8 +59,9 @@ export const api = ky.create({
 export interface ListItemsParams {
   limit?: number
   offset?: number
-  sort?: string
-  feed_id?: string | string[]
+  feed_ids?: string[]
+  sortField?: 'published_at' | 'retrieved_at'
+  sortDirection?: 'asc' | 'desc'
 }
 
 export interface ListRecentItemsResponse {
@@ -71,27 +72,24 @@ export interface ListRecentItemsResponse {
 export async function listRecentItems({
   limit = 50,
   offset = 0,
-  sort,
-  feed_id,
+  sortField,
+  sortDirection,
+  feed_ids,
 }: ListItemsParams = {}): Promise<ListRecentItemsResponse> {
   const searchParams = new URLSearchParams()
-  if (limit) {
-    searchParams.set('limit', String(limit))
+  searchParams.set('limit', String(limit))
+  searchParams.set('offset', String(offset))
+
+  if (sortField && sortDirection) {
+    searchParams.set('sort', `${sortField}:${sortDirection}`)
   }
-  if (offset) {
-    searchParams.set('offset', String(offset))
-  }
-  if (sort) {
-    searchParams.set('sort', sort)
-  }
-  if (Array.isArray(feed_id)) {
-    for (const id of feed_id) {
+
+  if (Array.isArray(feed_ids)) {
+    for (const id of feed_ids) {
       if (id) {
         searchParams.append('feed_id', id)
       }
     }
-  } else if (feed_id) {
-    searchParams.set('feed_id', feed_id)
   }
 
   const response = await api.get('items', { searchParams })

--- a/web/src/lib/query.ts
+++ b/web/src/lib/query.ts
@@ -5,7 +5,7 @@ import type { ListItemsParams, SearchItemsParams } from './api'
 
 export const queryKeys = {
   health: () => ['health'] as const,
-  recentItems: (params: ListItemsParams = {}) => ['items', params] as const,
+  recentItems: (params: ListItemsParams) => ['items', params] as const,
   search: (params: SearchItemsParams) => ['search', params] as const,
   feeds: () => ['feeds'] as const,
 }

--- a/web/src/lib/useRecentItemsQuery.ts
+++ b/web/src/lib/useRecentItemsQuery.ts
@@ -1,9 +1,15 @@
 import { useQuery, type UseQueryOptions, type UseQueryResult } from '@tanstack/react-query'
 
-import { listRecentItems, type ListRecentItemsResponse } from '@/lib/api'
+import {
+  listRecentItems,
+  type ListItemsParams,
+  type ListRecentItemsResponse,
+} from '@/lib/api'
 import { queryKeys } from '@/lib/query'
 
-export type RecentItemsSort = 'published_at:desc' | 'published_at:asc'
+export type RecentItemsSortField = NonNullable<ListItemsParams['sortField']>
+export type RecentItemsSortDirection = NonNullable<ListItemsParams['sortDirection']>
+export type RecentItemsSort = `${RecentItemsSortField}:${RecentItemsSortDirection}`
 
 export interface RecentItemsQueryState {
   feeds: string[]
@@ -27,12 +33,21 @@ export function buildListParams({
   const offset = (safePage - 1) * limit
   const feedIds = [...feeds].filter((id) => typeof id === 'string' && id.length > 0)
   const sortedFeedIds = feedIds.length > 0 ? [...new Set(feedIds)].sort() : undefined
+  const [sortFieldRaw, sortDirectionRaw] = sort.split(':') as [
+    RecentItemsSortField?,
+    RecentItemsSortDirection?,
+  ]
+  const sortField: RecentItemsSortField =
+    sortFieldRaw === 'retrieved_at' ? 'retrieved_at' : 'published_at'
+  const sortDirection: RecentItemsSortDirection =
+    sortDirectionRaw === 'asc' ? 'asc' : 'desc'
 
   return {
     limit,
     offset,
-    sort,
-    feed_id: sortedFeedIds,
+    sortField,
+    sortDirection,
+    feed_ids: sortedFeedIds,
   } as const
 }
 

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -22,10 +22,12 @@ import {
   buildQueryKey,
   useRecentItemsQuery,
   type RecentItemsSort,
+  type RecentItemsSortField,
 } from '@/lib/useRecentItemsQuery'
 
 const PAGE_SIZE = 20
 const DEFAULT_SORT: RecentItemsSort = 'published_at:desc'
+const SORTABLE_FIELDS: RecentItemsSortField[] = ['published_at', 'retrieved_at']
 
 export const Route = createFileRoute('/')({
   validateSearch: (search) => ({
@@ -322,8 +324,14 @@ function parsePage(value: unknown): number {
 }
 
 function parseSort(value: unknown): RecentItemsSort {
-  if (value === 'published_at:asc' || value === 'published_at:desc') {
-    return value
+  if (typeof value === 'string') {
+    const [field, direction] = value.split(':') as [string, string]
+    if (
+      SORTABLE_FIELDS.includes(field as RecentItemsSortField) &&
+      (direction === 'asc' || direction === 'desc')
+    ) {
+      return `${field}:${direction}` as RecentItemsSort
+    }
   }
   return DEFAULT_SORT
 }


### PR DESCRIPTION
## Summary
- extend the recent items API helper to send pagination by default and support multiple feed filters plus explicit sort field/direction pairs
- update the React Query helpers and ItemTable to build the richer parameter object and derive stable sort handling
- allow the home route to parse the broader sort options and keep cache keys aligned with the new inputs

## Testing
- pnpm test *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68e684a7b4588325b017908c1dd099fe