### PR TITLE
Fix search route page parsing

### DIFF
--- a/web/src/lib/parsePage.ts
+++ b/web/src/lib/parsePage.ts
@@ -1,0 +1,4 @@
+export function parsePage(value: unknown): number {
+  const numeric = typeof value === 'string' ? Number.parseInt(value, 10) : Number(value)
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 1
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -25,6 +25,8 @@ import {
   type RecentItemsSortField,
 } from '@/lib/useRecentItemsQuery'
 
+import { parsePage } from '@/lib/parsePage'
+
 const PAGE_SIZE = 20
 const DEFAULT_SORT: RecentItemsSort = 'published_at:desc'
 const SORTABLE_FIELDS: RecentItemsSortField[] = ['published_at', 'retrieved_at']
@@ -316,11 +318,6 @@ function parseFeeds(value: unknown): string[] {
     return [value]
   }
   return []
-}
-
-function parsePage(value: unknown): number {
-  const numeric = typeof value === 'string' ? Number.parseInt(value, 10) : Number(value)
-  return Number.isFinite(numeric) && numeric > 0 ? numeric : 1
 }
 
 function parseSort(value: unknown): RecentItemsSort {

--- a/web/src/routes/search.tsx
+++ b/web/src/routes/search.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/select'
 import { listFeeds, searchItems } from '@/lib/api'
 import { queryKeys } from '@/lib/query'
+import { parsePage } from '@/lib/parsePage'
 
 const PAGE_SIZE = 20
 const SAVED_SEARCHES = [
@@ -31,7 +32,7 @@ const SAVED_SEARCHES = [
 export const Route = createFileRoute('/search')({
   validateSearch: (search) => ({
     q: typeof search.q === 'string' ? search.q : '',
-    page: typeof search.page === 'number' && search.page > 0 ? search.page : 1,
+    page: parsePage(search.page),
     feed: typeof search.feed === 'string' ? search.feed : '',
     startDate: typeof search.startDate === 'string' ? search.startDate : undefined,
     endDate: typeof search.endDate === 'string' ? search.endDate : undefined,


### PR DESCRIPTION
## Summary
- extract a shared `parsePage` helper for consistent pagination parsing
- use the shared helper in the search route so string query params keep their numeric value

## Testing
- `pnpm --filter web build` *(fails: rollup cannot resolve optional dependency `react-day-picker`)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ddb8dce0832592c3c81e471ee0cb