### PR TITLE
Prevent duplicate error toasts on search page

### DIFF
--- a/web/src/lib/query.ts
+++ b/web/src/lib/query.ts
@@ -1,7 +1,11 @@
-import { QueryClient } from '@tanstack/react-query'
+import { QueryCache, QueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { ListItemsParams, SearchItemsParams } from './api'
+
+type QueryMeta = {
+  skipGlobalErrorToast?: boolean
+}
 
 export const queryKeys = {
   health: () => ['health'] as const,
@@ -11,19 +15,29 @@ export const queryKeys = {
 }
 
 export function createQueryClient() {
+  const queryCache = new QueryCache({
+    onError: (error, query) => {
+      const meta = query?.meta as QueryMeta | undefined
+
+      if (meta?.skipGlobalErrorToast) {
+        return
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Please try again later.'
+      toast.error('Request failed', {
+        description: message,
+      })
+    },
+  })
+
   return new QueryClient({
+    queryCache,
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
         retry: 1,
         staleTime: 30_000,
-        onError: (error) => {
-          const message =
-            error instanceof Error ? error.message : 'Please try again later.'
-          toast.error('Request failed', {
-            description: message,
-          })
-        },
       },
     },
   })

--- a/web/src/routes/search.tsx
+++ b/web/src/routes/search.tsx
@@ -140,6 +140,7 @@ function SearchRoute() {
     queryKey: queryKeys.feeds(),
     queryFn: () => listFeeds(),
     staleTime: 5 * 60 * 1000,
+    meta: { skipGlobalErrorToast: true },
     onError: (error) => {
       console.error('Failed to load feeds', error)
       const message =
@@ -176,6 +177,7 @@ function SearchRoute() {
     }),
     enabled: q.trim().length > 0,
     keepPreviousData: true,
+    meta: { skipGlobalErrorToast: true },
     onError: (error) => {
       console.error('Search request failed', error)
       const message =


### PR DESCRIPTION
## Summary
- move the global request failure toast into the query cache to allow opt-outs
- add a skip flag for queries that show contextual toasts on the search page
- ensure the feeds and search queries only surface their scoped error messages

## Testing
- pnpm test *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68e6df322f108325a7e1060565aa3768