### PR TITLE
Add Prometheus metrics instrumentation

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"courier/internal/httpx"
 	"courier/internal/logx"
@@ -25,7 +24,6 @@ func main() {
 	meiliURL := requireEnv(svc, "MEILI_URL")
 
 	metrics := httpx.NewMetrics(svc)
-	prometheus.MustRegister(metrics.Collectors()...)
 
 	db, err := sql.Open("pgx", dsn)
 	if err != nil {


### PR DESCRIPTION
## Summary
- create a dedicated Prometheus metrics registry for the API service
- record HTTP request counts/durations and external dependency timings
- wire the API server to expose the metrics endpoint and propagate the metrics helper

## Testing
- go test ./internal/...
- go test ./cmd/...
- go test ./internal/httpx -run TestItems -v

------
https://chatgpt.com/codex/tasks/task_e_68e6f807c72483259e1f1429acffd452