### PR TITLE
Add stack traces to debug error logs

### DIFF
--- a/internal/logx/log.go
+++ b/internal/logx/log.go
@@ -3,6 +3,8 @@ package logx
 import (
 	"encoding/json"
 	"os"
+	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 )
@@ -13,12 +15,14 @@ type Event struct {
 	Svc   string    `json:"service"`
 	Msg   string    `json:"msg"`
 	Err   string    `json:"err,omitempty"`
+	Stack string    `json:"stack,omitempty"`
 	Extra any       `json:"extra,omitempty"`
 }
 
 var (
 	enc = json.NewEncoder(os.Stdout)
 	mu  sync.Mutex
+	dbg = strings.EqualFold(os.Getenv("LOG_LEVEL"), "debug")
 )
 
 func log(ev Event) {
@@ -35,6 +39,9 @@ func Error(service, msg string, err error, extra any) {
 	ev := Event{Ts: time.Now().UTC(), Level: "error", Svc: service, Msg: msg, Extra: extra}
 	if err != nil {
 		ev.Err = err.Error()
+		if dbg {
+			ev.Stack = string(debug.Stack())
+		}
 	}
 	log(ev)
 }


### PR DESCRIPTION
## Summary
- derive a debug-mode flag from LOG_LEVEL
- capture stack traces for error logs when debug mode is enabled
- include stack field in log events while keeping NDJSON output unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6fff1cc1883258ea5b369df5b09f7