### PR TITLE
Sanitize DSN secrets in config snapshot

### DIFF
--- a/internal/httpx/config.go
+++ b/internal/httpx/config.go
@@ -225,5 +225,15 @@ func sanitizeDSN(dsn string) string {
 			parsed.User = url.User("")
 		}
 	}
+	if parsed.RawQuery != "" {
+		q := parsed.Query()
+		for key := range q {
+			switch strings.ToLower(key) {
+			case "password", "pass", "pwd", "password_file":
+				delete(q, key)
+			}
+		}
+		parsed.RawQuery = q.Encode()
+	}
 	return parsed.String()
 }

--- a/internal/httpx/config_test.go
+++ b/internal/httpx/config_test.go
@@ -1,0 +1,44 @@
+package httpx
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestRuntimeConfigSnapshotSanitizesDSN(t *testing.T) {
+	cfg := RuntimeConfig{
+		Service: "test",
+		Database: DatabaseConfig{
+			Driver: "pgx",
+			DSN:    "postgres://user:secret@localhost:5432/db?sslmode=disable&password=secret&pass=foo&pwd=bar&password_file=/tmp/file&keep=this",
+		},
+	}
+
+	snapshot := cfg.Snapshot()
+	sanitized := snapshot.Database.DSN
+
+	parsed, err := url.Parse(sanitized)
+	if err != nil {
+		t.Fatalf("failed to parse sanitized DSN: %v", err)
+	}
+
+	if parsed.User == nil {
+		t.Fatalf("expected user information to be present")
+	}
+
+	if _, hasPassword := parsed.User.Password(); hasPassword {
+		t.Fatalf("expected user password to be removed from DSN, got %q", sanitized)
+	}
+
+	query := parsed.Query()
+	sensitiveKeys := []string{"password", "pass", "pwd", "password_file"}
+	for _, key := range sensitiveKeys {
+		if _, exists := query[key]; exists {
+			t.Fatalf("expected sensitive query parameter %q to be removed", key)
+		}
+	}
+
+	if got := query.Get("keep"); got != "this" {
+		t.Fatalf("expected non-sensitive query parameter to remain, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- strip known sensitive query parameters when sanitizing database DSNs
- add a RuntimeConfig snapshot test ensuring userinfo passwords and sensitive query params are removed

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e707691ef48325b9c9bb676ae22155