### PR TITLE
feat: centralize runtime config parsing

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -58,6 +58,9 @@ func main() {
 	})
 	srv.HTTPErrorHandler = httpx.HTTPErrorHandler(svc)
 	httpx.RegisterConfigRoute(srv, runtimeCfg)
+	if runtimeCfg.Expose {
+		logx.Info(svc, "config route enabled", map[string]any{"path": "/config"})
+	}
 
 	addr := runtimeCfg.HTTP.Addr
 

--- a/internal/httpx/config.go
+++ b/internal/httpx/config.go
@@ -90,42 +90,122 @@ func LoadRuntimeConfig(service string) (RuntimeConfig, error) {
 		},
 	}
 
-	dsn := strings.TrimSpace(os.Getenv("COURIER_DSN"))
+	if v := envString("COURIER_SERVICE_NAME"); v != "" {
+		cfg.Service = v
+	}
+
+	cfg.HTTP.Addr = stringWithDefault("COURIER_HTTP_ADDR", cfg.HTTP.Addr)
+
+	shutdownTimeout, err := durationFromEnv("COURIER_HTTP_SHUTDOWN_TIMEOUT", cfg.HTTP.ShutdownTimeout)
+	if err != nil {
+		return cfg, err
+	}
+	if shutdownTimeout <= 0 {
+		return cfg, fmt.Errorf("COURIER_HTTP_SHUTDOWN_TIMEOUT must be greater than zero")
+	}
+	cfg.HTTP.ShutdownTimeout = shutdownTimeout
+
+	cfg.Database.Driver = stringWithDefault("COURIER_DB_DRIVER", cfg.Database.Driver)
+
+	maxOpenConns, err := intFromEnv("COURIER_DB_MAX_OPEN_CONNS", cfg.Database.MaxOpenConns)
+	if err != nil {
+		return cfg, err
+	}
+	if maxOpenConns < 0 {
+		return cfg, fmt.Errorf("COURIER_DB_MAX_OPEN_CONNS must be non-negative")
+	}
+	cfg.Database.MaxOpenConns = maxOpenConns
+
+	maxIdleConns, err := intFromEnv("COURIER_DB_MAX_IDLE_CONNS", cfg.Database.MaxIdleConns)
+	if err != nil {
+		return cfg, err
+	}
+	if maxIdleConns < 0 {
+		return cfg, fmt.Errorf("COURIER_DB_MAX_IDLE_CONNS must be non-negative")
+	}
+	cfg.Database.MaxIdleConns = maxIdleConns
+
+	connMaxLifetime, err := durationFromEnv("COURIER_DB_CONN_MAX_LIFETIME", cfg.Database.ConnMaxLifetime)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Database.ConnMaxLifetime = connMaxLifetime
+
+	pingTimeout, err := durationFromEnv("COURIER_DB_PING_TIMEOUT", cfg.Database.PingTimeout)
+	if err != nil {
+		return cfg, err
+	}
+	if pingTimeout <= 0 {
+		return cfg, fmt.Errorf("COURIER_DB_PING_TIMEOUT must be greater than zero")
+	}
+	cfg.Database.PingTimeout = pingTimeout
+
+	dsn := envString("COURIER_DSN")
 	if dsn == "" {
 		return cfg, fmt.Errorf("COURIER_DSN is required")
 	}
 	cfg.Database.DSN = dsn
 
-	searchURL := strings.TrimSpace(os.Getenv("MEILI_URL"))
+	searchURL := envString("MEILI_URL")
 	if searchURL == "" {
 		return cfg, fmt.Errorf("MEILI_URL is required")
 	}
 	cfg.Search.URL = searchURL
 
-	if v := strings.TrimSpace(os.Getenv("COURIER_EVERY")); v != "" {
-		interval, err := time.ParseDuration(v)
-		if err != nil {
-			return cfg, fmt.Errorf("invalid COURIER_EVERY: %w", err)
-		}
-		cfg.Fetcher.Interval = interval
+	interval, err := durationFromEnv("COURIER_EVERY", cfg.Fetcher.Interval)
+	if err != nil {
+		return cfg, err
 	}
-
-	if v := strings.TrimSpace(os.Getenv("COURIER_BATCH_UPSERT")); v != "" {
-		batchSize, err := strconv.Atoi(v)
-		if err != nil {
-			return cfg, fmt.Errorf("invalid COURIER_BATCH_UPSERT: %w", err)
-		}
-		if batchSize <= 0 {
-			return cfg, fmt.Errorf("COURIER_BATCH_UPSERT must be a positive integer")
-		}
-		cfg.Fetcher.BatchSize = batchSize
+	if interval <= 0 {
+		return cfg, fmt.Errorf("COURIER_EVERY must be greater than zero")
 	}
+	cfg.Fetcher.Interval = interval
 
-	if v := strings.TrimSpace(os.Getenv("COURIER_EXPOSE_CONFIG")); v != "" {
+	batchSize, err := intFromEnv("COURIER_BATCH_UPSERT", cfg.Fetcher.BatchSize)
+	if err != nil {
+		return cfg, err
+	}
+	if batchSize <= 0 {
+		return cfg, fmt.Errorf("COURIER_BATCH_UPSERT must be a positive integer")
+	}
+	cfg.Fetcher.BatchSize = batchSize
+
+	backoffMin, err := durationFromEnv("COURIER_BACKOFF_MIN", cfg.Fetcher.Backoff.Min)
+	if err != nil {
+		return cfg, err
+	}
+	if backoffMin <= 0 {
+		return cfg, fmt.Errorf("COURIER_BACKOFF_MIN must be greater than zero")
+	}
+	cfg.Fetcher.Backoff.Min = backoffMin
+
+	backoffMax, err := durationFromEnv("COURIER_BACKOFF_MAX", cfg.Fetcher.Backoff.Max)
+	if err != nil {
+		return cfg, err
+	}
+	if backoffMax <= 0 {
+		return cfg, fmt.Errorf("COURIER_BACKOFF_MAX must be greater than zero")
+	}
+	if backoffMax < cfg.Fetcher.Backoff.Min {
+		return cfg, fmt.Errorf("COURIER_BACKOFF_MAX must be greater than or equal to COURIER_BACKOFF_MIN")
+	}
+	cfg.Fetcher.Backoff.Max = backoffMax
+
+	backoffFactor, err := floatFromEnv("COURIER_BACKOFF_FACTOR", cfg.Fetcher.Backoff.Factor)
+	if err != nil {
+		return cfg, err
+	}
+	if backoffFactor <= 0 {
+		return cfg, fmt.Errorf("COURIER_BACKOFF_FACTOR must be greater than zero")
+	}
+	cfg.Fetcher.Backoff.Factor = backoffFactor
+
+	if v := envString("COURIER_EXPOSE_CONFIG"); v != "" {
 		expose, err := strconv.ParseBool(v)
-		if err == nil {
-			cfg.Expose = expose
+		if err != nil {
+			return cfg, fmt.Errorf("invalid COURIER_EXPOSE_CONFIG: %w", err)
 		}
+		cfg.Expose = expose
 	}
 
 	return cfg, nil
@@ -226,4 +306,51 @@ func sanitizeDSN(dsn string) string {
 		}
 	}
 	return parsed.String()
+}
+
+func envString(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}
+
+func stringWithDefault(key, fallback string) string {
+	if v := envString(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) {
+	if v := envString(key); v != "" {
+		duration, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s: %w", key, err)
+		}
+		if duration < 0 {
+			return 0, fmt.Errorf("%s must not be negative", key)
+		}
+		return duration, nil
+	}
+	return fallback, nil
+}
+
+func intFromEnv(key string, fallback int) (int, error) {
+	if v := envString(key); v != "" {
+		value, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s: %w", key, err)
+		}
+		return value, nil
+	}
+	return fallback, nil
+}
+
+func floatFromEnv(key string, fallback float64) (float64, error) {
+	if v := envString(key); v != "" {
+		value, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s: %w", key, err)
+		}
+		return value, nil
+	}
+	return fallback, nil
 }


### PR DESCRIPTION
## Summary
- centralize runtime config parsing with typed env helpers and defaults
- expose additional settings (HTTP, database, fetcher backoff) while sanitizing secrets
- log when the optional /config endpoint is enabled for dev inspection

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e7088790f88325bd4540e78db3ad45