### PR TITLE
Improve feed panic logging and transient detection

### DIFF
--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -200,11 +200,13 @@ func processFeed(ctx context.Context, svc string, repo feedRepository, searchCli
 				}
 				newDocsRemaining = 0
 			}
-			err := fmt.Errorf("panic: %v", r)
+			panicValue := fmt.Sprintf("%v", r)
+			err := fmt.Errorf("panic: %s", panicValue)
 			logx.Error(svc, "feed panic", err, map[string]any{
-				"feed":    f.URL,
-				"feed_id": f.ID,
-				"stack":   string(debug.Stack()),
+				"feed":        f.URL,
+				"feed_id":     f.ID,
+				"panic_value": panicValue,
+				"stack":       string(debug.Stack()),
 			})
 			if result.Err != nil {
 				result.Err = errors.Join(result.Err, err)

--- a/internal/feed/fetch.go
+++ b/internal/feed/fetch.go
@@ -133,8 +133,18 @@ func isTransientFetchError(err error) bool {
 		return true
 	}
 
-	if errors.Is(err, syscall.ECONNRESET) {
-		return true
+	transientSyscalls := []error{
+		syscall.ECONNRESET,
+		syscall.ECONNREFUSED,
+		syscall.ECONNABORTED,
+		syscall.EPIPE,
+		syscall.EHOSTUNREACH,
+		syscall.ENETUNREACH,
+	}
+	for _, target := range transientSyscalls {
+		if errors.Is(err, target) {
+			return true
+		}
 	}
 
 	var netErr net.Error


### PR DESCRIPTION
## Summary
- include the recovered panic value alongside the stack trace when a feed goroutine panics
- treat additional network syscall failures as transient so they participate in the lightweight retry backoff

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e830438bf0832599d4a853cc64d5f7