### PR TITLE
Add per-feed panic recovery and transient retry handling

### DIFF
--- a/internal/feed/fetch.go
+++ b/internal/feed/fetch.go
@@ -74,6 +74,10 @@ func (f *Fetcher) Fetch(ctx context.Context, url, etag, lastModified string) (Re
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusRequestTimeout {
+			return res, fmt.Errorf("%w: http status %d", ErrTransientFetch, resp.StatusCode)
+		}
+
 		if IsRetryable(resp.StatusCode) {
 			res.RetryAfter = parseRetryAfter(resp.Header.Get("Retry-After"))
 			return res, ErrRetryLater


### PR DESCRIPTION
## Summary
- wrap feed processing with a panic recovery guard that logs the stack and preserves the fetch loop
- keep the existing processing logic in a helper while trimming pending search documents when a panic occurs
- classify HTTP request timeouts as transient fetch errors so they use the transient backoff tracker instead of the rate-limit backoff

## Testing
- go test ./... *(fails: test suite hangs waiting for external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e832e00dbc83258f5e4ea83780d4db