### PR TITLE
Improve panic recovery logging and rate limit error context

### DIFF
--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -200,6 +200,9 @@ func recoverFeedPanic(svc string, f store.Feed, pendingDocs *[]search.Document, 
 			} else {
 				result.Err = panicErr
 			}
+			if result.Status == 0 {
+				result.Status = http.StatusInternalServerError
+			}
 			result.Skipped = true
 			if result.Reason == "" {
 				result.Reason = "panic"

--- a/internal/feed/fetch.go
+++ b/internal/feed/fetch.go
@@ -81,7 +81,7 @@ func (f *Fetcher) Fetch(ctx context.Context, url, etag, lastModified string) (Re
 
 		if isRateLimited(resp.StatusCode) {
 			res.RetryAfter = parseRetryAfter(resp.Header.Get("Retry-After"))
-			return res, ErrRetryLater
+			return res, fmt.Errorf("%w: http status %d", ErrRetryLater, resp.StatusCode)
 		}
 
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))


### PR DESCRIPTION
## Summary
- set a 500 status on recovered feed panics so they are clearly reported
- wrap rate limit fetch errors with HTTP status context while preserving the sentinel

## Testing
- go test ./... *(fails: command hung against integration dependencies, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68e844a996248325aadeb82cb3a6cac8